### PR TITLE
feat: control end need to login before access

### DIFF
--- a/src/rendezvous_server.rs
+++ b/src/rendezvous_server.rs
@@ -813,6 +813,18 @@ impl RendezvousServer {
             });
             return Ok((msg_out, None));
         }
+        if ph.token.is_empty() && std::env::var("LOGGED_IN_ONLY")
+            .unwrap_or_default()
+            .to_uppercase()
+            == "Y"
+        {
+            let mut msg_out = RendezvousMessage::new();
+            msg_out.set_punch_hole_response(PunchHoleResponse {
+                other_failure: String::from("The connection is not allowed. You have not logged in."),
+                ..Default::default()
+            });
+            return Ok((msg_out, None));
+        }
         let id = ph.id;
         // punch hole request from A, relay to B,
         // check if in same intranet first,


### PR DESCRIPTION
### This commit provide "The control end need to login before access" feature.
close https://github.com/sctg-development/sctgdesk-api-server/issues/14

I made this because my service was used by a scammer. This caused my IP to be blocked by my ISP.

Usage: Use `LOGGED_IN_ONLY=Y hbbs` to start, or add `LOGGED_IN_ONLY=Y` to the environment.

If the client is logged in, the token in PunchHoleRequest is access_token, otherwise, it is empty. It only checks if the control side is logged in, not if the session is valid.
The API side might need some modifications to provide a way to verify access_token, but I can't think of a way to do this.