### PR TITLE
refactor: limit unwanted access

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,8 @@ sctgdesk-api-server = { git = "https://github.com/sctg-development/sctgdesk-api-
 rocket = { version = "0.5", features = ["json", "secrets"] }
 num_cpus = "1.16"
 
+reqwest = { version = "0.12", default-features = false, features = ["json","rustls-tls"] }
+
 [build-dependencies]
 hbb_common = { path = "libs/hbb_common" }
 

--- a/src/rendezvous_server.rs
+++ b/src/rendezvous_server.rs
@@ -45,6 +45,9 @@ use std::{
     time::Instant,
 };
 
+use reqwest::Client;
+use serde_json::json;
+
 #[derive(Clone, Debug)]
 enum Data {
     Msg(Box<RendezvousMessage>, SocketAddr),
@@ -815,17 +818,39 @@ impl RendezvousServer {
         }
         // For limiting abuse, only allow logged in users to punch hole
         // if LOGGED_IN_ONLY=Y is set in env or --logged-in-only is passed
-        if ph.token.is_empty() && std::env::var("LOGGED_IN_ONLY")
+        if std::env::var("LOGGED_IN_ONLY")
             .unwrap_or_default()
             .to_uppercase()
             == "Y"
         {
             let mut msg_out = RendezvousMessage::new();
-            msg_out.set_punch_hole_response(PunchHoleResponse {
-                other_failure: String::from("The connection is not allowed. You have not logged in."),
-                ..Default::default()
-            });
-            return Ok((msg_out, None));
+            if !ph.token.is_empty() {
+                let api_server = std::env::var("API_SERVER").unwrap_or_else(|_| "http://127.0.0.1:21114".to_string());
+                let api_url = api_server + "/api/currentUser";
+                let client = Client::new();
+                let res = client.post(&api_url)
+                    .bearer_auth(ph.token)
+                    .json(&json!({ "id": ph.id, "uuid": "uuid" }))
+                    .send()
+                    .await?;
+                if res.status().is_success() {
+                    let response_body: serde_json::Value = res.json().await?;
+                    log::debug!("Username: {}", response_body["name"]);
+                } else {
+                    log::debug!("Error: {}", res.status());
+                    msg_out.set_punch_hole_response(PunchHoleResponse {
+                        other_failure: String::from("The connection is not allowed. Your session expired."),
+                        ..Default::default()
+                    });
+                    return Ok((msg_out, None));
+                }
+            } else {
+                msg_out.set_punch_hole_response(PunchHoleResponse {
+                    other_failure: String::from("The connection is not allowed. You have not logged in."),
+                    ..Default::default()
+                });
+                return Ok((msg_out, None));
+            }
         }
         let id = ph.id;
         // punch hole request from A, relay to B,


### PR DESCRIPTION
Refactored the "Limit Unwanted Access" feature to validate tokens via api server. Close #19 

The default API endpoint is http://127.0.0.1:21114, making it ready to use out of the box. The default value can be overridden by setting the API_SERVER environment variable.