### PR TITLE
Update relay_server.rs connection speed limits

### DIFF
--- a/src/relay_server.rs
+++ b/src/relay_server.rs
@@ -39,9 +39,9 @@ lazy_static::lazy_static! {
 
 static DOWNGRADE_THRESHOLD_100: AtomicUsize = AtomicUsize::new(66); // 0.66
 static DOWNGRADE_START_CHECK: AtomicUsize = AtomicUsize::new(1_800_000); // in ms
-static LIMIT_SPEED: AtomicUsize = AtomicUsize::new(4 * 1024 * 1024); // in bit/s
+static LIMIT_SPEED: AtomicUsize = AtomicUsize::new(24 * 1024 * 1024); // in bit/s
 static TOTAL_BANDWIDTH: AtomicUsize = AtomicUsize::new(1024 * 1024 * 1024); // in bit/s
-static SINGLE_BANDWIDTH: AtomicUsize = AtomicUsize::new(16 * 1024 * 1024); // in bit/s
+static SINGLE_BANDWIDTH: AtomicUsize = AtomicUsize::new(32 * 1024 * 1024); // in bit/s
 const BLACKLIST_FILE: &str = "blacklist.txt";
 const BLOCKLIST_FILE: &str = "blocklist.txt";
 


### PR DESCRIPTION
default connection speed limits is low. 4mbps file transfer is too low. upped it to 24mbps and upper single bandwith to 32. total - same 1000mbps